### PR TITLE
Fix link cards not showing with no links

### DIFF
--- a/cards/standard.py
+++ b/cards/standard.py
@@ -559,7 +559,15 @@ class CardMixin:
             object: The card object, or None if links is empty.
         """
         if not links:
-            return None
+            # language=HTML
+            html = '<div style="padding: 20px;"><p class="text-center">No links</p></div>'
+            return self.add_card(
+                card_name=card_name,
+                title=title,
+                group_type=CARD_TYPE_HTML,
+                html=html,
+                **kwargs,
+            )
         # Assign image_index for lightbox navigation (only counting image-type links)
         image_idx = 0
         for link in links:


### PR DESCRIPTION
Make a link card show a "No Links" message when no links are present, rather than not showing at all. 